### PR TITLE
Remove useless space in translations.

### DIFF
--- a/po-export/live-installer/live-installer-ru.po
+++ b/po-export/live-installer/live-installer-ru.po
@@ -46,7 +46,7 @@ msgstr ""
 "ОШИБКА: Установочный носитель поврежден или записан неправильно! Эта ошибка "
 "обычно является следствием записи носителя с помощью несовместимых с LMDE "
 "программ (YUMI или другие мультизагрузочные утилиты). Пожалуйста, запишите "
-"ISO образ на Ваш  DVD/USB носитель с помощью другой программы."
+"ISO образ на Ваш DVD/USB носитель с помощью другой программы."
 
 #: usr/lib/live-installer/installer.py:159
 msgid "Indexing files to be copied.."
@@ -180,7 +180,7 @@ msgstr "Установка Linux Mint..."
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:101
 msgid "Installation paused: please finish the custom installation"
-msgstr "Установка приостановлена:  завершите пользовательскую установку"
+msgstr "Установка приостановлена: завершите пользовательскую установку"
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:114
 msgid "Country"
@@ -231,7 +231,7 @@ msgstr "Обзор"
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:239
 msgid "Calculating file indexes ..."
-msgstr "Вычисление  файлового индекса..."
+msgstr "Вычисление файлового индекса..."
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:311
 msgid "Images"
@@ -480,7 +480,7 @@ msgstr "Пожалуйста, укажите Ваше полное имя."
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:757
 msgid "Please provide a username."
-msgstr "Пожалуйста, укажите  имя пользователя."
+msgstr "Пожалуйста, укажите имя пользователя."
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:760
 msgid "Please provide a password for your user account."
@@ -540,7 +540,7 @@ msgstr ""
 #: usr/lib/live-installer/frontend/gtk_interface.py:813
 msgid "The EFI partition is not bootable. Please edit the partition flags."
 msgstr ""
-"Раздел EFI  не является загрузочным. Пожалуйста, отредактируйте метки "
+"Раздел EFI не является загрузочным. Пожалуйста, отредактируйте метки "
 "раздела."
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:816
@@ -679,7 +679,7 @@ msgid ""
 "The installation is now complete. Do you want to restart your computer to "
 "use the new system?"
 msgstr ""
-"Установка завершена. Вы хотите перезагрузить компьютер  для применения "
+"Установка завершена. Вы хотите перезагрузить компьютер для применения "
 "изменений?"
 
 #: usr/lib/live-installer/partitioning.py:129

--- a/po-export/live-installer/live-installer-uk.po
+++ b/po-export/live-installer/live-installer-uk.po
@@ -181,7 +181,7 @@ msgstr "Встановлення Linux Mint..."
 #: usr/lib/live-installer/frontend/gtk_interface.py:101
 msgid "Installation paused: please finish the custom installation"
 msgstr ""
-"Встановлення призупинено: будь ласка, закінчіть  вибіркове встановлення"
+"Встановлення призупинено: будь ласка, закінчіть вибіркове встановлення"
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:114
 msgid "Country"
@@ -402,7 +402,7 @@ msgid ""
 msgstr ""
 "Зверніть увагу, що для того, щоб оновлені unitramfs працювали належним чином "
 "в деяких випадках (наприклад, dm-crypt), Вам може бути потрібно мати диски "
-"встановлені в даний час  за допомогою того ж блоку ім'я пристрою, як вони "
+"встановлені в даний час за допомогою того ж блоку ім'я пристрою, як вони "
 "відображуються в /target/etc/fstab."
 
 #: usr/lib/live-installer/frontend/gtk_interface.py:431

--- a/po-export/mintinstall/mintinstall-ru.po
+++ b/po-export/mintinstall/mintinstall-ru.po
@@ -48,7 +48,7 @@ msgstr "Пакет '%s' не может быть установлен"
 #: usr/lib/linuxmint/mintInstall/mintinstall.py:198
 #, python-format
 msgid "The package '%s' could not be removed"
-msgstr "Пакет '%s' не может быть  удалён"
+msgstr "Пакет '%s' не может быть удалён"
 
 #: usr/lib/linuxmint/mintInstall/mintinstall.py:204
 msgid "Please check your connection to the Internet"


### PR DESCRIPTION
Accidentally I've found that some files contains double space and it seems that they don't have special meaning. I've removed them.